### PR TITLE
feat: allow multi-select and rich_text property type update

### DIFF
--- a/.github/workflows/on_master.yml
+++ b/.github/workflows/on_master.yml
@@ -45,4 +45,5 @@ jobs:
           gh-token: ${{ secrets.GH_ACCESS_TOKEN }}
           notion-key: ${{ secrets.NOTION_KEY }}
           notion-property-name: "Version Tag"
+          notion-property-type: "multi_select"
           notion-update-value: "${{ steps.version.outputs.new_tag }}"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ GitHub action to update a Notion page property on commit created by merging a Pu
 
 Originally built for updating version tag in Notion page on commit. See [the test workflow](.github/workflows/on_master.yml) as an example.
 
+Notes:
+
+- Only able to work on a property that is of type `text`
+- Current appending logic assumes that no formatting is done in the property, i.e. all plain text only
+
 ## Example Usage
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ GitHub action to update a Notion page property on commit created by merging a Pu
 
 Originally built for updating version tag in Notion page on commit. See [the test workflow](.github/workflows/on_master.yml) as an example.
 
-Notes:
-
-- Only able to work on a property that is of type `text`
-- Current appending logic assumes that no formatting is done in the property, i.e. all plain text only
-
 ## Example Usage
 
 ```yml
@@ -20,13 +15,22 @@ with:
   gh-token: ${{ secrets.GH_ACCESS_TOKEN }}
   notion-key: ${{ secrets.NOTION_KEY }}
   notion-property-name: "Status"
+  notion-property-name: "multi_select"
   notion-update-value: "Merged"
 ```
+
+Required properties
 
 - `gh-username`: GitHub username of user who has access to the repository
 - `gh-token`: GitHub access token of user who has access to the repository
 - `notion-key`: Notion Integration Secret Key
 - `notion-property-name`: Notion Page property to be updated
 - `notion-update-value`: New value for Notion page property
+
+Optional properties:
+
+- `notion-property-type`: Type of Notion Page property
+  - Currently supports type `rich_text` and `multi_select`
+  - Defaults to `rich_text` if not specified
 
 The [test workflow](.github/workflows/on_master.yml) is linked to [this Notion database](https://szenius.notion.site/4964f7c754f54c41abce56028d990ac6?v=9ece5b75d4914584b43685bcbc6f3d1c).

--- a/index.js
+++ b/index.js
@@ -17,14 +17,32 @@ const updateNotionStory = async (
   value
 ) => {
   const notion = new Client({ auth: notionKey });
-  await notion.pages.update({
-    page_id: notionPageId,
-    properties: {
-      [propertyName]: {
-        rich_text: [{ type: "text", text: { content: value } }],
+
+  const pageDetails = await notion.pages.retrieve({ page_id: notionPageId });
+  
+  const existingPropertyValues = pageDetails.properties[propertyName].rich_text;
+
+  if (existingPropertyValues.length === 0) {
+    await notion.pages.update({
+      page_id: notionPageId,
+      properties: {
+        [propertyName]: {
+          rich_text: [{ type: "text", text: { content: value } }],
+        },
       },
-    },
-  });
+    });
+  } else {
+    const existingValue = existingPropertyValues[0].plain_text;
+    const combinedValue = `${existingValue},${value}`;
+    await notion.pages.update({
+      page_id: notionPageId,
+      properties: {
+        [propertyName]: {
+          rich_text: [{ type: "text", text: { content: combinedValue } }],
+        },
+      },
+    });
+  }
 };
 
 const extractFirstNotionPageId = (prDescription) => {

--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ const getConfig = () => {
       accessToken: process.env.GH_ACCESS_TOKEN,
       notionKey: process.env.NOTION_KEY,
       notionPropertyName: process.env.NOTION_PROPERTY_NAME,
+      notionPropertyType: process.env.NOTION_PROPERTY_TYPE,
       notionUpdateValue: process.env.NOTION_UPDATE_VALUE,
     };
   }
@@ -115,11 +116,14 @@ const getConfig = () => {
     accessToken: core.getInput("gh-token"),
     notionKey: core.getInput("notion-key"),
     notionPropertyName: core.getInput("notion-property-name"),
+    notionPropertyType: core.getInput("notion-property-type"),
     notionUpdateValue: core.getInput("notion-update-value"),
   };
 };
 
 const run = async () => {
+  const supportedPropertyTypes = ["rich_text", "multi_select"];
+
   const {
     commitHash,
     repoOwner,
@@ -128,8 +132,15 @@ const run = async () => {
     accessToken,
     notionKey,
     notionPropertyName,
+    notionPropertyType,
     notionUpdateValue,
   } = getConfig();
+
+  if (!(notionPropertyType in supportedPropertyTypes)) {
+    core.setFailed(
+      `Type of Notion Page property ${notionPropertyType} is not supported.`
+    );
+  }
 
   let prDescription = "";
   try {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ const { Client } = require("@notionhq/client");
 
 require("dotenv").config();
 
+const supportedPropertyTypes = {"rich_text": "rich_text", "multi_select": "multi_select"};
+
 const getGitHubRequestHeaders = (username, accessToken) => ({
   headers: { Authorization: `Basic ${btoa(`${username}:${accessToken}`)}` },
 });
@@ -14,35 +16,53 @@ const updateNotionStory = async (
   notionKey,
   notionPageId,
   propertyName,
-  value
+  value,
+  propertyType
 ) => {
   const notion = new Client({ auth: notionKey });
 
   const pageDetails = await notion.pages.retrieve({ page_id: notionPageId });
-  
-  const existingPropertyValues = pageDetails.properties[propertyName].rich_text;
 
-  if (existingPropertyValues.length === 0) {
-    await notion.pages.update({
-      page_id: notionPageId,
-      properties: {
-        [propertyName]: {
-          rich_text: [{ type: "text", text: { content: value } }],
+  if (propertyType === supportedPropertyTypes.rich_text) {
+    const existingPropertyValues = pageDetails.properties[propertyName].rich_text;
+  
+    if (existingPropertyValues.length === 0) {
+      await notion.pages.update({
+        page_id: notionPageId,
+        properties: {
+          [propertyName]: {
+            rich_text: [{ type: "text", text: { content: value } }],
+          },
         },
-      },
-    });
-  } else {
-    const existingValue = existingPropertyValues[0].plain_text;
-    const combinedValue = `${existingValue},${value}`;
+      });
+    } else {
+      const existingValue = existingPropertyValues[0].plain_text;
+      const combinedValue = `${existingValue},${value}`;
+      await notion.pages.update({
+        page_id: notionPageId,
+        properties: {
+          [propertyName]: {
+            rich_text: [{ type: "text", text: { content: combinedValue } }],
+          },
+        },
+      });
+    }
+  }
+
+  if (propertyType === supportedPropertyTypes.multi_select) {
+    const existingPropertyValues = pageDetails.properties[propertyName].multi_select;
+    existingPropertyValues.push({"name": value})
+
     await notion.pages.update({
       page_id: notionPageId,
       properties: {
         [propertyName]: {
-          rich_text: [{ type: "text", text: { content: combinedValue } }],
+          multi_select: existingPropertyValues,
         },
       },
     });
   }
+  
 };
 
 const extractFirstNotionPageId = (prDescription) => {
@@ -122,8 +142,6 @@ const getConfig = () => {
 };
 
 const run = async () => {
-  const supportedPropertyTypes = ["rich_text", "multi_select"];
-
   const {
     commitHash,
     repoOwner,
@@ -175,7 +193,8 @@ const run = async () => {
       notionKey,
       notionPageId,
       notionPropertyName,
-      notionUpdateValue
+      notionUpdateValue,
+      notionPropertyType || supportedPropertyTypes.rich_text
     );
   } catch (error) {
     core.setFailed(`Error updating Notion page ${notionPageId}: ${error}`);


### PR DESCRIPTION
[Notion link](https://www.notion.so/immalim/Test-on-master-workflow-works-246957b570c74298a0cc9887111c4ece)

This PR adds the ability to select either rich_text or multi_select for the property type to be updated~ Defaults to rich_text
